### PR TITLE
Dark mode changes

### DIFF
--- a/ietf115-london/agenda.css
+++ b/ietf115-london/agenda.css
@@ -1,4 +1,34 @@
+:root {
+  color-scheme: light dark;
+  --background-color: #ffffff; /* white background */
+}
+@media (prefers-color-scheme: light) {
+  :root {
+      --background-color: #ffffff; /* white background */
+  }
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+      --background-color: #000000; /* black background */
+  }
+}
 body {font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;}
 table {border-collapse: collapse; width: 80%;}
-td, th {border: 1px solid #ddd; padding: 8px;}
-tr:nth-child(even){background-color: #f2f2f2;}
+@media (prefers-color-scheme: light) {
+    td, th {
+        border: 1px solid #ddd;
+        padding: 8px;
+    }
+    tr:nth-child(even){
+        background-color: #f2f2f2;
+    }
+}
+@media (prefers-color-scheme: dark) {
+    td, th {
+        border: 1px solid #444;
+        padding: 8px;
+    }
+    tr:nth-child(even){
+        background-color: #2f2f2f;
+    }
+}

--- a/ietf115-london/agenda.html
+++ b/ietf115-london/agenda.html
@@ -6,18 +6,54 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>IPPM Agenda IETF 115</title>
   <style>
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
-  </style>
-  <style type="text/css">body {font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;}
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+width: 0.8em;
+margin: 0 0.8em 0.2em -1.6em;
+vertical-align: middle;
+}
+.display.math{display: block; text-align: center; margin: 0.5rem auto;}
+</style>
+  <style type="text/css">:root {
+color-scheme: light dark;
+--background-color: #ffffff; 
+}
+@media (prefers-color-scheme: light) {
+:root {
+--background-color: #ffffff; 
+}
+}
+@media (prefers-color-scheme: dark) {
+:root {
+--background-color: #000000; 
+}
+}
+body {font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;}
 table {border-collapse: collapse; width: 80%;}
-td, th {border: 1px solid #ddd; padding: 8px;}
-tr:nth-child(even){background-color: #f2f2f2;}</style>
+@media (prefers-color-scheme: light) {
+td, th {
+border: 1px solid #ddd;
+padding: 8px;
+}
+tr:nth-child(even){
+background-color: #f2f2f2;
+}
+}
+@media (prefers-color-scheme: dark) {
+td, th {
+border: 1px solid #444;
+padding: 8px;
+}
+tr:nth-child(even){
+background-color: #2f2f2f;
+}
+}
+</style>
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
   <![endif]-->
@@ -27,10 +63,16 @@ tr:nth-child(even){background-color: #f2f2f2;}</style>
 <h1 class="title">IPPM Agenda IETF 115</h1>
 </header>
 <p><em>When</em> Monday 7 November 2022, 9:30-11:30 GMT</p>
-<p><em>Where:</em> Mezzanine 1-4, https://meetings.conf.meetecho.com/ietf115/?group=ippm</p>
+<p><em>Where:</em> Mezzanine 1-4, <a href>https://meetings.conf.meetecho.com/ietf115/?group=ippm</a></p>
 <p><em>Chairs:</em> Tommy Pauly &amp; Marcus Ihlar</p>
 <h1 id="working-group-documents">Working Group Documents</h1>
-<table>
+<table style="width:100%;">
+<colgroup>
+<col style="width: 11%" />
+<col style="width: 10%" />
+<col style="width: 59%" />
+<col style="width: 18%" />
+</colgroup>
 <thead>
 <tr class="header">
 <th>Time</th>
@@ -103,8 +145,15 @@ tr:nth-child(even){background-color: #f2f2f2;}</style>
 </tbody>
 </table>
 <h1 id="proposed-work">Proposed Work</h1>
-<p>Individual drafts that have received list discussion and are candidates for adoption.</p>
-<table>
+<p>Individual drafts that have received list discussion and are
+candidates for adoption.</p>
+<table style="width:100%;">
+<colgroup>
+<col style="width: 11%" />
+<col style="width: 10%" />
+<col style="width: 59%" />
+<col style="width: 18%" />
+</colgroup>
 <thead>
 <tr class="header">
 <th>Time</th>

--- a/ietf115-london/agenda.md
+++ b/ietf115-london/agenda.md
@@ -1,6 +1,6 @@
 *When*   Monday 7 November 2022, 9:30-11:30 GMT
 
-*Where:*  Mezzanine 1-4, https://meetings.conf.meetecho.com/ietf115/?group=ippm
+*Where:*  Mezzanine 1-4, [https://meetings.conf.meetecho.com/ietf115/?group=ippm]()
 
 *Chairs:* Tommy Pauly & Marcus Ihlar
 


### PR DESCRIPTION
The main change is only to agenda.css which will now generate an HTML file that works in both dark and light mode.

There is an additional change to the original markdown file agenda.md to make the URL a link but this isn't necessary.

The changes to agenda.html are generated by running the pandoc command in mkagenda.sh